### PR TITLE
Data table

### DIFF
--- a/cbtttheme2017.libraries.yml
+++ b/cbtttheme2017.libraries.yml
@@ -14,8 +14,7 @@ global-css:
 global-js:
   js:
     'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js': { type: external,  minified: true }
-    'https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js': { type: external,  minified: true }
-    'https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap.min.js': { type: external,  minified: true }
+    'https://cdn.datatables.net/v/bs/jq-2.2.4/dt-1.10.15/r-2.1.1/datatables.min.js': { type: external,  minified: true }
     js/stellarnav.min.js: {}
     js/menuDropdown.js: {} 
     js/main.js: {}

--- a/cbtttheme2017.libraries.yml
+++ b/cbtttheme2017.libraries.yml
@@ -13,8 +13,6 @@ global-css:
 
 global-js:
   js:
-    'https://code.jquery.com/jquery-1.12.4.js': { type: external,  minified: true }
-    'https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js': { type: external,  minified: true }
     'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js': { type: external,  minified: true }
     'https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js': { type: external,  minified: true }
     'https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap.min.js': { type: external,  minified: true }
@@ -23,6 +21,7 @@ global-js:
     js/main.js: {}
     js/offCanvas.js: {}
     js/cbttNav.js: {}
+    js/cbttDataTable.js: {}
   dependencies:
     - core/jquery
     - core/jquery.ui.datepicker

--- a/js/cbttDataTable.js
+++ b/js/cbttDataTable.js
@@ -1,8 +1,7 @@
 (function ($) {
-
-  Drupal.behaviors.exampleModule = {
+  Drupal.behaviors.applyBootstrapDataTable = {
     attach: function (context, settings) {
-      $('#example').DataTable();
+      $('#example, .bootstrap-data-table-view table', context).DataTable();
     }
   }
 

--- a/js/cbttDataTable.js
+++ b/js/cbttDataTable.js
@@ -1,0 +1,9 @@
+(function ($) {
+
+  Drupal.behaviors.exampleModule = {
+    attach: function (context, settings) {
+      $('#example').DataTable();
+    }
+  }
+
+})(jQuery);

--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -51,14 +51,6 @@
       {{ 'Skip to main content'|t }}
     </a>
     {{ page_top }}
-       <script type="text/javascript">
-      jQuery(document).ready(function ($) {
-      jQuery('[data-toggle="offcanvas"]').click(function () {
-        jQuery('.row-offcanvas').toggleClass('active')
-      });
-    });
-
-  </script>
     {{ page }}
     {{ page_bottom }}
     <js-bottom-placeholder token="{{ placeholder_token }}">

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -52,39 +52,6 @@
 <header>
   <div class="container">
 
-  <script>
-  (function ($) { 
-  		jQuery(document).ready(function($) {
-  			jQuery('.stellarnav').stellarNav({
-  				theme: 'light'
-  			});
-  		});
-  })(jQuery);
-
-
-
-
-  </script>
-
-
-
-
-
-
-
-  <script>
-        (function ($) {
-
-          Drupal.behaviors.exampleModule = {
-            attach: function (context, settings) {
-           $('#example').DataTable();
-              };
-            }
-          };
-
-        })(jQuery);
-  </script>
-
 
 
 


### PR DESCRIPTION
Fixes datatable js, and applies vanilla dataTable ti example selectors (`#example` and `.bootstrap-data-table-view`). The plugin can be further configured in the file themes/custom/cbtttheme2017/js/cbttDataTable.js using the options [here](https://datatables.net/reference/option/) 